### PR TITLE
Export as library

### DIFF
--- a/src/fengari-web.js
+++ b/src/fengari-web.js
@@ -1,12 +1,15 @@
 "use strict";
 
-const fengari  = require('fengari');
-const lua      = fengari.lua;
-const lauxlib  = fengari.lauxlib;
-const lualib   = fengari.lualib;
-const interop  = require('fengari-interop');
+import {lua, lauxlib, lualib} from 'fengari';
+import * as interop from 'fengari-interop';
 
-const L = lauxlib.luaL_newstate();
+export {
+	lua,
+	lauxlib,
+	lualib,
+	interop
+};
+export const L = lauxlib.luaL_newstate();
 
 /* open standard libraries */
 lualib.luaL_openlibs(L);

--- a/src/fengari-web.js
+++ b/src/fengari-web.js
@@ -34,6 +34,24 @@ const msghandler = function(L) {
 	return 1;
 };
 
+/* Helper function to load a JS string of Lua source */
+export function load(code, chunkname) {
+	code = lua.to_luastring(code);
+	chunkname = chunkname?lua.to_luastring(chunkname):null;
+	let ok = lauxlib.luaL_loadbuffer(L, code, null, chunkname);
+	let res;
+	if (ok === lua.LUA_ERRSYNTAX) {
+		res = new SyntaxError(lua.lua_tojsstring(L, -1));
+	} else {
+		res = interop.tojs(L, -1);
+	}
+	lua.lua_pop(L, 1);
+	if (ok !== lua.LUA_OK) {
+		throw res;
+	}
+	return res;
+}
+
 const run_lua_script = function(tag, code, chunkname) {
 	let ok = lauxlib.luaL_loadbuffer(L, code, null, chunkname);
 	let e;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,9 @@ module.exports = [
         target: 'web',
         output: {
             path: path.resolve(__dirname, 'dist'),
-            filename: 'fengari-web.js'
+            filename: 'fengari-web.js',
+            library: 'fengari',
+            libraryTarget: 'umd'
         },
         node: false,
         module: {


### PR DESCRIPTION
Uses umd.

In most cases will end up with `fengari` global on window object.

Closes #19 
Obsoletes https://github.com/fengari-lua/fengari-interop/pull/14